### PR TITLE
Fix types and increment version number

### DIFF
--- a/src/init.luau
+++ b/src/init.luau
@@ -244,7 +244,7 @@ end
 function Module.attributeChanged(
 	instance: Instance,
 	attribute: string,
-	callback: (new: any?, old: any?) -> (),
+	callback: (new: any, old: any) -> (),
 	skip: boolean?
 )
 	local old = instance:GetAttribute(attribute)
@@ -261,7 +261,7 @@ end
 
 function Module.anyAttributeChanged(
 	instance: Instance,
-	callback: (attribute: string, new: any?, old: any?) -> (),
+	callback: (attribute: string, new: any, old: any) -> (),
 	skip: boolean?
 )
 	local old = {}

--- a/src/wally.toml
+++ b/src/wally.toml
@@ -1,6 +1,6 @@
 [package]
 name = "solarscuffle-bot/connectutil"
-version = "1.3.0"
+version = "1.3.1"
 registry = "https://github.com/UpliftGames/wally-index"
 realm = "shared"
 


### PR DESCRIPTION
Because of the way the arguments are typed in the `callback` function of `attributeChanged`:
```lua
function Module.attributeChanged(
    instance: Instance,
    attribute: string,
    callback: (new: any?, old: any?) -> (),
    skip: boolean?
)
```
A type error is emitted when annotating the parameters of the passed function:

![image](https://github.com/SolarScuffle-Bot/ConnectUtil/assets/94771866/403b7c6e-ec9e-4196-9093-99dd5db035ec)

Since we are already saying the parameters will be `any` type (including `nil`), I believe it's reasonable to type it as non-optional.