### PR TITLE
Fix potential issue with getPlayerFromPart

### DIFF
--- a/src/init.luau
+++ b/src/init.luau
@@ -31,7 +31,7 @@ function Module.getPlayerFromPart(part: BasePart): (Player?, Model?, Humanoid?)
 		return nil, nil, nil
 	end
 
-	local humanoid = character:FindFirstAncestorWhichIsA 'Humanoid'
+	local humanoid = character:FindFirstChildWhichIsA 'Humanoid'
 
 	return player, character, humanoid
 end

--- a/src/init.luau
+++ b/src/init.luau
@@ -287,7 +287,7 @@ function Module.tagInstance(instance: Instance, tag: string, added: (Instance) -
 				added(instance)
 			end
 		end)
-		
+
 		for _, tagged in CollectionService:GetTagged(tag) do
 			added(tagged)
 		end
@@ -462,8 +462,9 @@ end
 export type Connection =
 	RBXScriptConnection
 	| { Disconnect: (any) -> () }
+	| { [any]: Connection }
 	| thread
 	| Instance
-	| () -> () | { [any]: Connection }
+	| () -> ()
 
 return Module

--- a/src/init.luau
+++ b/src/init.luau
@@ -18,16 +18,20 @@ local function onPlayerTouched(callback: (other: BasePart, player: Player, chara
 end
 
 --[=[
-	If the part is a character part, returns the character, the player the character is associated with, and the character's humanoid if present.
+	If the part is a character part, returns the player who owns that part, that player's character, and the character's humanoid (if present).
 ]=]
 function Module.getPlayerFromPart(part: BasePart): (Player?, Model?, Humanoid?)
 	local character = part:FindFirstAncestorWhichIsA 'Model'
-	if not character or character == workspace then
+	if not character then
 		return nil, nil, nil
 	end
 
 	local player = Players:GetPlayerFromCharacter(character)
-	local humanoid = character:FindFirstChildWhichIsA 'Humanoid'
+	if not player then
+		return nil, nil, nil
+	end
+
+	local humanoid = character:FindFirstAncestorWhichIsA 'Humanoid'
 
 	return player, character, humanoid
 end

--- a/src/wally.toml
+++ b/src/wally.toml
@@ -1,6 +1,6 @@
 [package]
 name = "solarscuffle-bot/connectutil"
-version = "2.0.1"
+version = "2.1.0"
 registry = "https://github.com/UpliftGames/wally-index"
 realm = "shared"
 


### PR DESCRIPTION
Before, the function could possibly return a model that is not a player character if that model is not workspace. Code that assumes a valid player character is always returned could break.
Minor version bump because some code might rely on this behavior.